### PR TITLE
Fixes for Fedora 28

### DIFF
--- a/cuda-gcc.spec
+++ b/cuda-gcc.spec
@@ -63,8 +63,17 @@ This package adds C++ support to the GNU Compiler Collection.
 %autosetup -p1 -n gcc-%{version}
 
 %build
-export CFLAGS=`echo %{optflags} | sed -e 's/-Werror=format-security//g'`
-export CXXFLAGS=`echo %{optflags} | sed -e 's/-Werror=format-security//g'`
+%if 0%{?fedora} >= 28
+export CFLAGS=`echo %{build_cflags} | sed -e 's/-Werror=format-security//g' | sed -e 's/-fstack-clash-protection -mcet -fcf-protection//g'`
+export CXXFLAGS=`echo %{build_cxxflags} | sed -e 's/-Werror=format-security//g' | sed -e 's/-fstack-clash-protection -mcet -fcf-protection//g'`
+export FFLAGS=`echo %{build_fflags} | sed -e 's/-Werror=format-security//g' | sed -e 's/-fstack-clash-protection -mcet -fcf-protection//g'`
+export FCFLAGS=`echo %{build_fflags} | sed -e 's/-Werror=format-security//g' | sed -e 's/-fstack-clash-protection -mcet -fcf-protection//g'`
+%else
+export CFLAGS=`echo %{build_cflags} | sed -e 's/-Werror=format-security//g'`
+export CXXFLAGS=`echo %{build_cxxflags} | sed -e 's/-Werror=format-security//g'`
+export FFLAGS=`echo %{build_fflags} | sed -e 's/-Werror=format-security//g'`
+export FCFLAGS=`echo %{build_fflags} | sed -e 's/-Werror=format-security//g'`
+%endif
 
 # Parameter '--enable-version-specific-runtime-libs' can't be used as it
 # prevents the proper include directories to be added by default to cc1/cc1plus


### PR DESCRIPTION
Hello,

cuda-gcc appears to be missing from Fedora 28 repository, so I tried to rebuild the RPM myself. This pull request contains the changes required to do so.

The first issue was that the default RPM build flags now contain switches not supported by the older compiler (```-fstack-clash-protection```, ```-mcet```, ```-fcf-protection```), so these need to be stripped away.

Then there was an issue with the annobin plugin not being reachable, which is worked around by disabling the annotated build feature.

Lastly, there was an error with gfortran, again due to the unsupported flags, hence the addition of cleaned-up FFLAGS and FCFLAGS.

Hope this helps, and thanks for your packaging efforts!

Cheers,
 Rok